### PR TITLE
Improve test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         "php": ">=5.3",
         "react/event-loop": "~0.4.0|~0.3.0",
         "clue/buzz-react": "~0.2.0",
-        "ext-simplexml": "*",
-        "ext-tidy": "*"
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "clue/block-react": "~0.1.0"

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Clue\React\Buzz\Browser;
 use Clue\React\Buzz\Message\Response;
 use React\Promise\Deferred;
+use Clue\React\ViewVcApi\Io\Parser;
 use Clue\React\ViewVcApi\Io\Loader;
 
 class Client

--- a/src/Io/Loader.php
+++ b/src/Io/Loader.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Clue\React\ViewVcApi\Io;
+
+use SimpleXMLElement;
+
+class Loader
+{
+    public function loadXmlFile($path)
+    {
+        return $this->loadXmlString(file_get_contents($path));
+    }
+
+    public function loadXmlString($html)
+    {
+        // clean up HTML to safe XML
+        $html = tidy_repair_string($html, array(
+            'output-xml' => true,
+            'input-xml'  => true,
+        ));
+
+        // clean up namespace declaration
+        $html = str_replace('xmlns="', 'ns="', $html);
+
+        return new SimpleXMLElement($html);
+    }
+}

--- a/src/Io/Loader.php
+++ b/src/Io/Loader.php
@@ -13,11 +13,11 @@ class Loader
 
     public function loadXmlString($html)
     {
-        // clean up HTML to safe XML
-        $html = tidy_repair_string($html, array(
-            'output-xml' => true,
-            'input-xml'  => true,
-        ));
+        // fix invalid markup of help link in footer of outdated ViewVC versions
+        $html = str_replace('Help</strong></td>', 'Help</a></strong></td>', $html);
+
+        // replace unneeded HTML entities
+        $html = str_replace('&nbsp;', ' ', $html);
 
         // clean up namespace declaration
         $html = str_replace('xmlns="', 'ns="', $html);

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -1,10 +1,12 @@
 <?php
 
-namespace Clue\React\ViewVcApi;
+namespace Clue\React\ViewVcApi\Io;
+
+use SimpleXMLElement;
 
 class Parser
 {
-    public function parseDirectoryListing($xml)
+    public function parseDirectoryListing(SimpleXMLElement $xml)
     {
         $files = array();
 
@@ -24,7 +26,7 @@ class Parser
         return $files;
     }
 
-    public function parseLogRevisions($xml)
+    public function parseLogRevisions(SimpleXMLElement $xml)
     {
         $revisions = array();
 

--- a/tests/FunctionalClientTest.php
+++ b/tests/FunctionalClientTest.php
@@ -14,7 +14,7 @@ class FunctionalClientTest extends TestCase
 
     public function setUp()
     {
-        $url = 'https://svn.apache.org/viewvc/';
+        $url = 'http://svn.apache.org/viewvc/';
 
         $this->loop = LoopFactory::create();
         $this->blocker = new Blocker($this->loop);

--- a/tests/Io/LoaderTest.php
+++ b/tests/Io/LoaderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Clue\React\ViewVcApi\Io\Loader;
+
+class LoaderTest extends TestCase
+{
+    private $loader;
+
+    public function setUp()
+    {
+        $this->loader = new Loader();
+    }
+
+    /**
+     * @dataProvider xmlFiles
+     * @param string $path
+     */
+    public function testValidXmlFixtures($path)
+    {
+        $xml = $this->loader->loadXmlFile(__DIR__ . '/../fixtures/' . $path);
+    }
+
+    public function xmlFiles()
+    {
+        return array_filter(array_map(
+            function ($path) {
+                return (substr($path, -5) === '.html') ? array($path) : null;
+            },
+            scandir(__DIR__ . '/../fixtures/')
+        ));
+    }
+}

--- a/tests/Io/ParserTest.php
+++ b/tests/Io/ParserTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Clue\React\ViewVcApi\Io\Parser;
+use Clue\React\ViewVcApi\Io\Loader;
+
+class ParserTest extends TestCase
+{
+    private $loader;
+    private $parser;
+
+    public function setUp()
+    {
+        $this->loader = new Loader();
+        $this->parser = new Parser();
+    }
+
+    public function testLogRevisions()
+    {
+        $xml = $this->loadXml('is-a-file.html');
+
+        $revisions = $this->parser->parseLogRevisions($xml);
+
+        $this->assertEquals(array('168703' => '168695', '168695' => '168694'), $revisions);
+    }
+
+    public function testDirectoryListing()
+    {
+        $xml = $this->loadXml('listing.html');
+
+        $files = $this->parser->parseDirectoryListing($xml);
+
+        $this->assertEquals(array('images/', 'stylesheets/', 'index.xml', 'velocity.properties'), $files);
+    }
+
+    private function loadXml($file)
+    {
+        return $this->loader->loadXmlFile(__DIR__ . '/../fixtures/' . $file);
+    }
+}

--- a/tests/fixtures/is-a-file.html
+++ b/tests/fixtures/is-a-file.html
@@ -1,0 +1,329 @@
+
+
+
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!-- ViewVC :: http://www.viewvc.org/ -->
+<head>
+<title>[Apache-SVN] Log of /jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java</title>
+<meta name="generator" content="ViewVC 1.2-dev" />
+<link rel="shortcut icon" href="/viewvc/*docroot*/images/favicon.ico" type="image/x-icon" />
+<link rel="stylesheet" href="/viewvc/*docroot*/styles.css" type="text/css" />
+
+</head>
+<body>
+<div class="vc_navheader">
+<table><tr>
+<td><strong><a href="/viewvc?view=roots"><span class="pathdiv">/</span></a><a href="/viewvc/?pathrev=1030540">[Apache-SVN]</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/?pathrev=1030540">jakarta</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/?pathrev=1030540">ecs</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/?pathrev=1030540">tags</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/V1_0/?pathrev=1030540">V1_0</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/V1_0/src/?pathrev=1030540">src</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/?pathrev=1030540">java</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/?pathrev=1030540">org</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/?pathrev=1030540">apache</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/?pathrev=1030540">ecs</a><span class="pathdiv">/</span>AlignType.java</strong></td>
+<td style="text-align: right;"></td>
+</tr></table>
+</div>
+<div style="float: right; padding: 5px;"><a href="http://www.viewvc.org/" title="ViewVC Home"><img src="/viewvc/*docroot*/images/viewvc-logo.png" alt="ViewVC logotype" width="240" height="70" /></a></div>
+<h1>Log of /jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java</h1>
+
+<p style="margin:0;">
+
+<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/?pathrev=1030540"><img src="/viewvc/*docroot*/images/back_small.png" class="vc_icon" alt="Parent Directory" /> Parent Directory</a>
+
+| <a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?view=log&amp;pathrev=1030540"><img src="/viewvc/*docroot*/images/log.png" class="vc_icon" alt="Revision Log" /> Revision Log</a>
+
+
+
+
+</p>
+
+<hr />
+<table class="auto">
+
+
+
+<tr>
+<td>Links to HEAD:</td>
+<td>
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?view=markup">view</a>)
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?view=co">download</a>)
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?view=annotate">annotate</a>)
+</td>
+</tr>
+
+
+
+<tr>
+<td>Sticky Revision:</td>
+<td><form method="get" action="/viewvc" style="display: inline">
+<div style="display: inline">
+<input type="hidden" name="orig_pathrev" value="1030540"/><input type="hidden" name="orig_pathtype" value="FILE"/><input type="hidden" name="orig_view" value="log"/><input type="hidden" name="orig_path" value="jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java"/><input type="hidden" name="view" value="redirect_pathrev"/>
+
+<input type="text" name="pathrev" value="1030540" size="6"/>
+
+<input type="submit" value="Set" />
+</div>
+</form>
+
+<form method="get" action="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java" style="display: inline">
+<div style="display: inline">
+<input type="hidden" name="view" value="log"/>
+
+<input type="submit" value="Clear" />
+
+</div>
+</form>
+
+</td>
+</tr>
+</table>
+ 
+
+
+
+
+
+
+
+<div>
+<hr />
+
+<a name="rev168703"></a>
+
+
+Revision <a href="/viewvc?view=revision&amp;revision=168703"><strong>168703</strong></a> -
+
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?revision=168703&amp;view=markup&amp;pathrev=1030540">view</a>)
+
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?revision=168703&amp;view=co&amp;pathrev=1030540">download</a>)
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?annotate=168703&amp;pathrev=1030540">annotate</a>)
+
+
+
+- <a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?view=log&amp;r1=168703&amp;pathrev=1030540">[select for diffs]</a>
+
+
+
+
+<br />
+
+Modified
+
+<em>Tue Jun 22 22:46:43 1999 UTC</em>
+(15 years, 9 months ago)
+by <em>(unknown author)</em>
+
+
+
+
+
+
+
+
+
+<br />File length: 4131 byte(s)
+
+
+
+
+
+
+
+<br />Diff to <a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?r1=168695&amp;r2=168703&amp;pathrev=1030540">previous 168695</a>
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?r1=168695&amp;r2=168703&amp;pathrev=1030540&amp;diff_format=h">colored</a>)
+
+
+
+
+
+
+<pre class="vc_log">This commit was manufactured by cvs2svn to create tag 'V1_0'.</pre>
+</div>
+
+
+
+<div>
+<hr />
+
+<a name="rev168695"></a>
+
+
+Revision <a href="/viewvc?view=revision&amp;revision=168695"><strong>168695</strong></a> -
+
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?revision=168695&amp;view=markup&amp;pathrev=1030540">view</a>)
+
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?revision=168695&amp;view=co&amp;pathrev=1030540">download</a>)
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?annotate=168695&amp;pathrev=1030540">annotate</a>)
+
+
+
+- <a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?view=log&amp;r1=168695&amp;pathrev=1030540">[select for diffs]</a>
+
+
+
+
+<br />
+
+Modified
+
+<em>Tue Jun 22 02:15:08 1999 UTC</em>
+(15 years, 9 months ago)
+by <em>(unknown author)</em>
+
+<br />Original Path: <a href="/viewvc/jakarta/ecs/branches/ecs/src/java/org/apache/ecs/AlignType.java?view=log&amp;pathrev=168695"><em>jakarta/ecs/branches/ecs/src/java/org/apache/ecs/AlignType.java</em></a>
+
+
+
+
+
+
+
+
+
+<br />File length: 4131 byte(s)
+
+
+
+
+
+
+
+<br />Diff to <a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?r1=168694&amp;r2=168695&amp;pathrev=1030540">previous 168694</a>
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?r1=168694&amp;r2=168695&amp;pathrev=1030540&amp;diff_format=h">colored</a>)
+
+
+
+
+
+
+<pre class="vc_log">This commit was manufactured by cvs2svn to create branch 'ecs'.</pre>
+</div>
+
+
+
+<div>
+<hr />
+
+<a name="rev168694"></a>
+
+
+Revision <a href="/viewvc?view=revision&amp;revision=168694"><strong>168694</strong></a> -
+
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?revision=168694&amp;view=markup&amp;pathrev=1030540">view</a>)
+
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?revision=168694&amp;view=co&amp;pathrev=1030540">download</a>)
+
+(<a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?annotate=168694&amp;pathrev=1030540">annotate</a>)
+
+
+
+- <a href="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?view=log&amp;r1=168694&amp;pathrev=1030540">[select for diffs]</a>
+
+
+
+
+<br />
+
+Added
+
+<em>Tue Jun 22 02:15:08 1999 UTC</em>
+(15 years, 9 months ago)
+by <em>jonbolt</em>
+
+<br />Original Path: <a href="/viewvc/jakarta/ecs/trunk/src/java/org/apache/ecs/AlignType.java?view=log&amp;pathrev=168694"><em>jakarta/ecs/trunk/src/java/org/apache/ecs/AlignType.java</em></a>
+
+
+
+
+
+
+
+<br />File length: 4131 byte(s)
+
+
+
+
+
+
+
+
+
+
+
+<pre class="vc_log">Initial revision
+</pre>
+</div>
+
+ 
+
+
+ <hr />
+<p><a name="diff"></a>
+This form allows you to request diffs between any two revisions of this file.
+For each of the two "sides" of the diff,
+
+enter a numeric revision.
+
+</p>
+<form method="get" action="/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java" id="diff_select">
+<table cellpadding="2" cellspacing="0" class="auto">
+<tr>
+<td>&nbsp;</td>
+<td>
+<input type="hidden" name="pathrev" value="1030540"/><input type="hidden" name="view" value="diff"/>
+Diffs between
+
+<input type="text" size="12" name="r1"
+value="168703" />
+
+and
+
+<input type="text" size="12" name="r2" value="168694" />
+
+</td>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td>
+Type of Diff should be a
+<select name="diff_format" onchange="submit()">
+<option value="h" >Colored Diff</option>
+<option value="l" >Long Colored Diff</option>
+<option value="f" >Full Colored Diff</option>
+<option value="u" selected="selected">Unidiff</option>
+<option value="c" >Context Diff</option>
+<option value="s" >Side by Side</option>
+</select>
+<input type="submit" value=" Get Diffs " />
+</td>
+</tr>
+</table>
+</form>
+
+
+
+
+
+<hr />
+<table>
+<tr>
+<td><address><a href="mailto:infrastructure at apache.org">infrastructure at apache.org</a></address></td>
+<td style="text-align: right;"><strong><a href="/viewvc/*docroot*/help_log.html">ViewVC Help</a></strong></td>
+</tr>
+<tr>
+<td>Powered by <a href="http://viewvc.tigris.org/">ViewVC 1.2-dev</a></td>
+<td style="text-align: right;">&nbsp;</td>
+</tr>
+</table>
+</body>
+</html>
+
+

--- a/tests/fixtures/is-a-file.txt
+++ b/tests/fixtures/is-a-file.txt
@@ -1,0 +1,5 @@
+Description:
+Accessing a file results in its log output 
+
+Obtained from:
+https://svn.apache.org/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/AlignType.java?view=log&pathrev=1030540

--- a/tests/fixtures/listing.html
+++ b/tests/fixtures/listing.html
@@ -1,0 +1,231 @@
+
+
+
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!-- ViewVC :: http://www.viewvc.org/ -->
+<head>
+<title>[Apache-SVN] Index of /jakarta/ecs/tags/RELEASE_1_4/xdocs</title>
+<meta name="generator" content="ViewVC 1.2-dev" />
+<link rel="shortcut icon" href="/viewvc/*docroot*/images/favicon.ico" type="image/x-icon" />
+<link rel="stylesheet" href="/viewvc/*docroot*/styles.css" type="text/css" />
+
+</head>
+<body>
+<div class="vc_navheader">
+<table><tr>
+<td><strong><a href="/viewvc?view=roots"><span class="pathdiv">/</span></a><a href="/viewvc/">[Apache-SVN]</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/">jakarta</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/">ecs</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/">tags</a><span class="pathdiv">/</span><a href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/">RELEASE_1_4</a><span class="pathdiv">/</span>xdocs</strong></td>
+<td style="text-align: right;"></td>
+</tr></table>
+</div>
+<div style="float: right; padding: 5px;"><a href="http://www.viewvc.org/" title="ViewVC Home"><img src="/viewvc/*docroot*/images/viewvc-logo.png" alt="ViewVC logotype" width="240" height="70" /></a></div>
+<h1>Index of /jakarta/ecs/tags/RELEASE_1_4/xdocs</h1>
+
+
+<table class="auto">
+<tr><td>Files shown:</td><td><strong>2</strong>
+
+
+</td></tr>
+
+<tr>
+<td>Directory revision:</td>
+<td><a href="/viewvc?view=revision&amp;revision=168894" title="Revision 168894">168894</a> (of <a href="/viewvc?view=revision" title="Revision 1671711">1671711</a>)</td>
+</tr>
+
+<tr>
+<td>Sticky Revision:</td>
+<td><form method="get" action="/viewvc" style="display: inline">
+<div style="display: inline">
+<input type="hidden" name="orig_pathtype" value="DIR"/><input type="hidden" name="orig_view" value="dir"/><input type="hidden" name="orig_path" value="jakarta/ecs/tags/RELEASE_1_4/xdocs"/><input type="hidden" name="view" value="redirect_pathrev"/>
+
+<input type="text" name="pathrev" value="" size="6"/>
+
+<input type="submit" value="Set" />
+</div>
+</form>
+
+</td>
+</tr>
+
+
+</table>
+
+
+<p><a name="dirlist"></a></p>
+<hr />
+
+<table cellspacing="1" cellpadding="2">
+<thead>
+<tr>
+<th class="vc_header_sort" colspan="2">
+<a href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/?sortdir=down#dirlist">File</a>
+
+<img class="vc_sortarrow" alt=""
+width="13" height="13"
+src="/viewvc/*docroot*/images/up.png" />
+
+</th>
+<th class="vc_header">
+<a href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/?sortby=rev#dirlist">Rev.</a>
+
+</th>
+<th class="vc_header">
+<a href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/?sortby=date#dirlist">Age</a>
+
+</th>
+<th class="vc_header">
+<a href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/?sortby=author#dirlist">Author</a>
+
+</th>
+
+<th class="vc_header">
+<a href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/?sortby=log#dirlist">Last log entry</a>
+
+</th>
+
+</tr>
+</thead>
+<tbody>
+
+<tr class="vc_row_odd">
+<td colspan="2">
+<a href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/">
+<img src="/viewvc/*docroot*/images/back_small.png" alt="" class="vc_icon"
+/>&nbsp;Parent&nbsp;Directory</a>
+</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+
+<td>&nbsp;</td>
+
+</tr>
+
+
+<tr class="vc_row_even">
+<td colspan="2">
+
+<a name="images" href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/images/" title="View directory contents">
+
+<img src="/viewvc/*docroot*/images/dir.png" alt="" class="vc_icon" />
+images/</a>
+
+</td>
+
+
+
+<td>&nbsp;<strong>r168899</strong></td>
+
+<td>&nbsp;14 years</td>
+<td>&nbsp;</td>
+
+
+<td>&nbsp;This commit was manufactured by cvs2svn to create tag 'RELEASE_1_4'.</td>
+
+
+
+</tr>
+
+<tr class="vc_row_odd">
+<td colspan="2">
+
+<a name="stylesheets" href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/stylesheets/" title="View directory contents">
+
+<img src="/viewvc/*docroot*/images/dir.png" alt="" class="vc_icon" />
+stylesheets/</a>
+
+</td>
+
+
+
+<td>&nbsp;<strong>r168899</strong></td>
+
+<td>&nbsp;14 years</td>
+<td>&nbsp;</td>
+
+
+<td>&nbsp;This commit was manufactured by cvs2svn to create tag 'RELEASE_1_4'.</td>
+
+
+
+</tr>
+
+<tr class="vc_row_even">
+<td colspan="2">
+
+<a name="index.xml" href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/index.xml?view=log" title="View file revision log">
+
+<img src="/viewvc/*docroot*/images/text.png" alt="" class="vc_icon" />
+index.xml</a>
+
+</td>
+
+
+
+
+<td style="white-space: nowrap;">&nbsp;<strong>r168899</strong>
+
+</td>
+
+<td>&nbsp;14 years</td>
+<td>&nbsp;</td>
+
+
+<td>&nbsp;This commit was manufactured by cvs2svn to create tag 'RELEASE_1_4'.</td>
+
+
+
+</tr>
+
+<tr class="vc_row_odd">
+<td colspan="2">
+
+<a name="velocity.properties" href="/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/velocity.properties?view=log" title="View file revision log">
+
+<img src="/viewvc/*docroot*/images/text.png" alt="" class="vc_icon" />
+velocity.properties</a>
+
+</td>
+
+
+
+
+<td style="white-space: nowrap;">&nbsp;<strong>r168899</strong>
+
+</td>
+
+<td>&nbsp;14 years</td>
+<td>&nbsp;</td>
+
+
+<td>&nbsp;This commit was manufactured by cvs2svn to create tag 'RELEASE_1_4'.</td>
+
+
+
+</tr>
+
+</tbody>
+</table>
+
+
+
+
+
+<hr />
+<table>
+<tr>
+<td><address><a href="mailto:infrastructure at apache.org">infrastructure at apache.org</a></address></td>
+<td style="text-align: right;"><strong><a href="/viewvc/*docroot*/help_dirview.html">ViewVC Help</a></strong></td>
+</tr>
+<tr>
+<td>Powered by <a href="http://viewvc.tigris.org/">ViewVC 1.2-dev</a></td>
+<td style="text-align: right;">&nbsp;</td>
+</tr>
+</table>
+</body>
+</html>
+
+

--- a/tests/fixtures/listing.txt
+++ b/tests/fixtures/listing.txt
@@ -1,0 +1,6 @@
+Description:
+Accessing a directory shows a directory listing
+Paths always end with a slash and will redirect otherwise
+
+Source:
+https://svn.apache.org/viewvc/jakarta/ecs/tags/RELEASE_1_4/xdocs/

--- a/tests/fixtures/not-a-file.html
+++ b/tests/fixtures/not-a-file.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!-- ViewVC :: http://www.viewvc.org/ -->
+<head>
+<title>ViewVC Exception</title>
+</head>
+<body>
+<h3>An Exception Has Occurred</h3>
+
+
+
+<h4>Python Traceback</h4>
+<p><pre>
+Traceback (most recent call last):
+  File &quot;/usr/local/viewvc-install/viewvc-trunk-r2530/lib/viewvc.py&quot;, line 4531, in main
+    request.run_viewvc()
+  File &quot;/usr/local/viewvc-install/viewvc-trunk-r2530/lib/viewvc.py&quot;, line 393, in run_viewvc
+    self.view_func(self)
+  File &quot;/usr/local/viewvc-install/viewvc-trunk-r2530/lib/viewvc.py&quot;, line 2677, in view_checkout
+    fp, revision = request.repos.openfile(path, rev)
+  File &quot;/usr/local/viewvc-install/viewvc-trunk-r2530/lib/vclib/svn/svn_repos.py&quot;, line 392, in openfile
+    raise vclib.Error(&quot;Path '%s' is not a file.&quot; % path)
+Error: Path 'jakarta/ecs/tags/V1_0/src/java/org/apache/ecs' is not a file.
+
+</pre></p>
+
+
+</body>
+</html>

--- a/tests/fixtures/not-a-file.txt
+++ b/tests/fixtures/not-a-file.txt
@@ -1,0 +1,7 @@
+Description:
+Trying to download a directory results in this error page.
+status returns 200 OK, but displays an error message anyways.
+this also ignores the `content-type=text/plain` parameter and does not send an `etag` header.
+
+Source:
+https://svn.apache.org/viewvc/jakarta/ecs/tags/V1_0/src/java/org/apache/ecs/?revision=168703&view=co&pathrev=1030540&content-type=text/plain


### PR DESCRIPTION
Now also supports PHP 5.3 and HHVM.
- Avoid HTTPS requests (https://github.com/clue/php-buzz-react/issues/32)
- Drop dependency on `ext-tidy` (closes #3)
- Add a bunch of new tests and test fixtures
